### PR TITLE
More configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ Values:
 
 *help*: Query description, that will be used as metric description also. Optional.
 
+*static_labels*: Set of label names, and their static values. Optional.
+
+*labels*: List of labels, that has to match a column value, that must be `string`. Optional.
+
 *values*: List of values, that has to match a column value, that must be `float`. At least one.
 
 *query*: SQL query to select rows that will represent a metric sample.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Values:
 
 *password*: database user's password. Required.
 
+*driver_class_name*: Fully qualified name of the JDBC driver class. Optional.
+
 ```yaml
 connections:
   - url: 'jdbc:oracle:thin:@db:1521/ORCLPDB1'

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Values:
 
 *url*: JDBC URL to connect to database instances. Required.
 
-*username*: database user's name. Required.
+*username*: database user's name. Optional.
 
-*password*: database user's password. Required.
+*password*: database user's password. Optional.
 
 *driver_class_name*: Fully qualified name of the JDBC driver class. Optional.
 

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/JdbcConfig.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/JdbcConfig.java
@@ -81,16 +81,10 @@ class JdbcConfig {
 
             if (connObject.containsKey("username")) {
               connection.username = (String) connObject.get("username");
-            } else {
-              throw new IllegalArgumentException("JDBC Connection `username` is not defined. " +
-                  "This value is required to execute collector.");
             }
 
             if (connObject.containsKey("password")) {
               connection.password = (String) connObject.get("password");
-            } else {
-              throw new IllegalArgumentException("JDBC Connection `password` is not defined. " +
-                  "This value is required to execute collector.");
             }
 
             if (connObject.containsKey("driver_class_name")) {

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/JdbcConfig.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/JdbcConfig.java
@@ -92,6 +92,10 @@ class JdbcConfig {
               throw new IllegalArgumentException("JDBC Connection `password` is not defined. " +
                   "This value is required to execute collector.");
             }
+
+            if (connObject.containsKey("driver_class_name")) {
+              connection.driverClassName = (String) connObject.get("driver_class_name");
+            }
           }
         } else {
           throw new IllegalArgumentException("JDBC Job does not have a `connections` defined. " +
@@ -206,6 +210,10 @@ class JdbcConfig {
                 try {
                   LOGGER.info(String.format("JDBC Connection URL: %s", connection.url));
 
+                  if (connection.driverClassName != null) {
+                    Class.forName(connection.driverClassName);
+                  }
+
                   final Connection conn =
                       DriverManager.getConnection(
                           connection.url, connection.username, connection.password);
@@ -225,7 +233,7 @@ class JdbcConfig {
                               return Stream.empty();
                             }
                           });
-                } catch (SQLException e) {
+                } catch (SQLException | ClassNotFoundException e) {
                   LOGGER.log(Level.SEVERE, "Error connecting to database", e);
                   return Stream.empty();
                 }
@@ -333,6 +341,7 @@ class JdbcConfig {
     String url;
     String username;
     String password;
+    String driverClassName;
   }
 
   private static class JdbcJob {


### PR DESCRIPTION
This pull request adds two new options to the query configuration section.

1. `driver_class_name` can be used to specify the FQN of the JDBC driver for the query. This is useful for older JDBC drivers that don't expose a service provider.
2. `static_labels` can be used to specify a set of labels names together with their values which will be added to the metric.