### PR TITLE
add caching of queries and parallelize querying

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Values:
 
 *query_ref*: Reference to common queries shared between jobs.
 
+*cache_seconds*: How many seconds to cache query results until they are refreshed. Optional.
+
 `query` and `query_ref` are mutually exclusive. At least one of those has to be defined.
 
 ```yaml

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/JdbcCollector.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/JdbcCollector.java
@@ -12,6 +12,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import io.prometheus.client.Collector;

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/JdbcCollector.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/JdbcCollector.java
@@ -12,7 +12,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import io.prometheus.client.Collector;

--- a/src/test/java/no/sysco/middleware/metrics/prometheus/jdbc/JdbcConfigTest.java
+++ b/src/test/java/no/sysco/middleware/metrics/prometheus/jdbc/JdbcConfigTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.*;
 /**
  *
  */
+@SuppressWarnings("unchecked")
 public class JdbcConfigTest {
 
   @Test(expected = IllegalArgumentException.class)
@@ -185,7 +186,6 @@ public class JdbcConfigTest {
     assertNotNull(config);
   }
 
-
   @Test
   public void testConfigShouldBuildWithoutQueryRef() {
     JdbcConfig config = new JdbcConfig((Map<String, Object>) new Yaml().load("---\n" +
@@ -202,6 +202,43 @@ public class JdbcConfigTest {
         "    query: abc\n" +
         ""));
     assertNotNull(config);
+  }
+
+  @Test
+  public void testConfigShouldBuildWithCacheSeconds() {
+    JdbcConfig config = new JdbcConfig((Map<String, Object>) new Yaml().load("---\n" +
+        "jobs:\n" +
+        "- name: \"global\"\n" +
+        "  connections:\n" +
+        "  - url: jdbc\n" +
+        "    username: sys\n" +
+        "    password: sys\n" +
+        "  queries:\n" +
+        "  - name: jdbc\n" +
+        "    cache_seconds: 180\n" +
+        "    values:\n" +
+        "    - v1\n" +
+        "    query: abc\n" +
+        ""));
+    assertNotNull(config);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConfigShouldFailWithInvalidCacheSeconds() {
+    new JdbcConfig((Map<String, Object>) new Yaml().load("---\n" +
+        "jobs:\n" +
+        "- name: \"global\"\n" +
+        "  connections:\n" +
+        "  - url: jdbc\n" +
+        "    username: sys\n" +
+        "    password: sys\n" +
+        "  queries:\n" +
+        "  - name: jdbc\n" +
+        "    cache_seconds: -999\n" +
+        "    values:\n" +
+        "    - v1\n" +
+        "    query: abc\n" +
+        ""));
   }
 
 }

--- a/src/test/resources/multipleconfigs/second_config.yml
+++ b/src/test/resources/multipleconfigs/second_config.yml
@@ -1,14 +1,14 @@
 ---
 jobs:
-  - name: "local"
-    connections:
-      - url: 'jdbc:oracle:thin:@docker-vm:1521/ORCLPDB1'
-        username: 'system'
-        password: 'tosRDJnLR4Y=1'
-    queries:
-      - name: "db_users"
-        help: "Database Users"
-        values:
-          - "count"
-        query:  |
-          select count(1) count from dba_users
+- name: "local"
+  connections:
+  - url: 'jdbc:oracle:thin:@docker-vm:1521/ORCLPDB1'
+    username: 'system'
+    password: 'tosRDJnLR4Y=1'
+  queries:
+  - name: "db_users"
+    help: "Database Users"
+    values:
+      - "count"
+    query:  |
+      select count(1) count from dba_users


### PR DESCRIPTION
* queries that take too long can be cached by specifying a `cache_seconds` value. helpful for queries that take longer and may block other queries and lead to scrape timeouts