### PR TITLE
Add FreeMarker Templating Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It uses JDBC libraries to execute a SQL query that returns a `Float` result and 
 - [Getting Started](#getting-started)
 - [Startup](#startup)
 - [Configuration](#configuration)
+  - [Templating](#templating)
 - [Override metric prefix](#override-metric-prefix)
 - [JDBC drivers](#jdbc-drivers)
   - [`download-list` file format](#download-list-file-format)
@@ -89,13 +90,13 @@ execute queries.
 
 Values:
 
-*url*: JDBC URL to connect to database instances. Required.
+*url*: JDBC URL to connect to database instances. Templated. Required.
 
-*username*: database user's name. Optional.
+*username*: database user's name. Templated. Optional.
 
-*password*: database user's password. Optional.
+*password*: database user's password. Templated. Optional.
 
-*driver_class_name*: Fully qualified name of the JDBC driver class. Optional.
+*driver_class_name*: Fully qualified name of the JDBC driver class. Templated. Optional.
 
 ```yaml
 connections:
@@ -120,7 +121,7 @@ Values:
 
 *values*: List of values, that has to match a column value, that must be numbers. At least one.
 
-*query*: SQL query to select rows that will represent a metric sample.
+*query*: SQL query to select rows that will represent a metric sample. Templated.
 
 *query_ref*: Reference to common queries shared between jobs.
 
@@ -159,7 +160,22 @@ queries:
     SELECT count(1) "COUNT" FROM users
 ```
 
-Where `query1` is the key that will be used from `query` definition.
+Where `query1` is the key that will be used from `query` definition. The query
+values are templated as if they were used literally in the query definitions
+that are using them.
+
+### Templating
+
+Some strings from the configuration are treated as templates. The Prometheus
+JDBC exporter uses the [FreeMarker Template Language][ftl].
+
+Currently, the following interpolations are available:
+
+| Name | Description | Example |
+|-|-|-|
+| `env`| OS environment variables | `${env.HOME}` |
+
+[ftl]: https://freemarker.apache.org/docs/dgui_template_overallstructure.html
 
 ## Override metric prefix
 

--- a/examples/docker-compose/config.yml
+++ b/examples/docker-compose/config.yml
@@ -3,7 +3,7 @@ jobs:
   connections:
   - url: jdbc:mysql://mysql/mysql
     username: root
-    password: example
+    password: ${env.MYSQL_PASSWORD}
   queries:
   - name: db_users
     help: Database Users
@@ -16,7 +16,7 @@ jobs:
   connections:
   - url: jdbc:postgresql://postgresql/postgres
     username: postgres
-    password: example
+    password: ${env.PGPASSWORD}
   queries:
   - name: db_users
     help: Database Users

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     build: .
     environment:
       METRIC_PREFIX: prepackaged_jdbc
+      MYSQL_PASSWORD: example
+      PGPASSWORD: example
 
   # This shows how to download drivers at container startup time, and how to
   # inject the configuration via a volume mount.
@@ -43,6 +45,9 @@ services:
     command:
     - 0.0.0.0:5555
     - /app/config.yml
+    environment:
+      MYSQL_PASSWORD: example
+      PGPASSWORD: example
     volumes:
     - type: bind
       source: ./config.yml

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,13 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+            <version>2.3.31</version>
+        </dependency>
+
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
@@ -66,6 +73,7 @@
             <artifactId>simpleclient_servlet</artifactId>
             <version>0.0.21</version>
         </dependency>
+
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/FreemarkerOsEnvRenderer.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/FreemarkerOsEnvRenderer.java
@@ -1,0 +1,46 @@
+package no.sysco.middleware.metrics.prometheus.jdbc;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Map;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateExceptionHandler;
+
+public class FreemarkerOsEnvRenderer implements TemplateRenderer {
+
+    private final Configuration config;
+    private final Object data;
+
+    public FreemarkerOsEnvRenderer() {
+        config = initConfig();
+        data = Map.of("env", Map.copyOf(System.getenv()));
+    }
+
+    @Override
+    public String render(String template) {
+        try {
+            final var tpl = new Template(null, template, config);
+            final var result = new StringWriter();
+            tpl.process(data, result);
+            return result.toString();
+        } catch (TemplateException | IOException e) {
+            throw new RuntimeException("failed to render template", e);
+        }
+    }
+
+    private static final Configuration initConfig() {
+        final var cfg = new Configuration(Configuration.VERSION_2_3_31);
+        // Sets how errors will appear.
+        cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+        // Don't log exceptions inside FreeMarker that it will thrown at you anyway
+        cfg.setLogTemplateExceptions(false);
+        // Wrap unchecked exceptions thrown during template processing into TemplateExceptions
+        cfg.setWrapUncheckedExceptions(true);
+        // Do not fall back to higher scopes when reading a null loop variable
+        cfg.setFallbackOnNullLoopVariable(false);
+        return cfg;
+    }
+}

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/JdbcCollector.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/JdbcCollector.java
@@ -31,6 +31,8 @@ public class JdbcCollector extends Collector implements Collector.Describable {
     private volatile Collection<JdbcConfig> configs = List.of();
     private volatile Instant lastUpdate = Instant.EPOCH;
 
+    private final TemplateRenderer renderer = new FreemarkerOsEnvRenderer();
+
     private final Counter configReloadSuccess;
     private final Counter configReloadFailure;
 
@@ -65,6 +67,7 @@ public class JdbcCollector extends Collector implements Collector.Describable {
                         metricPrefix,
                         Config.parseYaml(configData),
                         ConnectionProvider.DRIVER_MANAGER,
+                        renderer,
                         clock));
             }
         }

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/TemplateRenderer.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/TemplateRenderer.java
@@ -1,0 +1,5 @@
+package no.sysco.middleware.metrics.prometheus.jdbc;
+
+public interface TemplateRenderer {
+    String render(String template);
+}

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/Config.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/Config.java
@@ -5,7 +5,6 @@ import static java.util.stream.Collectors.joining;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/ConfigObject.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/ConfigObject.java
@@ -8,15 +8,11 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import org.immutables.value.Value;
-import org.immutables.value.Value.Style.ImplementationVisibility;
-
 import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /** Meta annotation for Config interfaces. */
 @Target(TYPE)

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/ConnectionDef.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/ConnectionDef.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 /** Connection details to connect to a database instance and execute queries. */
 @ConfigObject
 @Value.Immutable
+@Value.Style(redactedMask = "***")
 @JsonDeserialize(builder = ImmutableConnectionDef.Builder.class)
 public interface ConnectionDef {
 
@@ -20,6 +21,7 @@ public interface ConnectionDef {
     Optional<String> username();
 
     /** Database user's password. */
+    @Value.Redacted
     Optional<String> password();
 
     /** Fully qualified name of the JDBC driver class. */

--- a/src/test/java/no/sysco/middleware/metrics/prometheus/jdbc/JdbcConfigTest.java
+++ b/src/test/java/no/sysco/middleware/metrics/prometheus/jdbc/JdbcConfigTest.java
@@ -64,7 +64,7 @@ class JdbcConfigTest {
         given(rs.getDouble("value")).willReturn(42d).willThrow(AssertionFailedError.class);
 
         // when
-        final var underTest = new JdbcConfig("test", config, connProvider, clock);
+        final var underTest = new JdbcConfig("test", config, connProvider, tpl -> tpl, clock);
 
         // then
         final var allSamples = underTest.runJobs().collect(toList());


### PR DESCRIPTION
So that the configuration can be templated. Currently supported for queries and database connections. Interpolations are currently supported via environment variables.