### PR TITLE
Don't push images for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,7 @@ jobs:
           });
 
     - name: Push Docker image
-      if: ${{ !github.event.pull_request || (github.event.pull_request.base.repo.owner.login == github.event.pull_request.head.repo.owner.login) }}
+      if: ${{ !github.event.pull_request || (github.actor != 'dependabot[bot]' && github.event.pull_request.base.repo.owner.login == github.event.pull_request.head.repo.owner.login) }}
       uses: actions/github-script@v5
       env:
         DOCKER_REGISTRY_USERNAME: ${{ github.actor }}


### PR DESCRIPTION
More details: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions?learn=dependency_version_updates&learnProduct=code-security#responding-to-events