### PR TITLE
Disable explicit Jackson property names

### DIFF
--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/Config.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/Config.java
@@ -19,7 +19,8 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 /** Configuration for the Prometheus JDBC Exporter. */
-@ConfigObject
+@ImmutableConfigObject
+@JacksonConfigObject
 @Value.Immutable
 @JsonDeserialize(builder = ImmutableConfig.Builder.class)
 public interface Config {

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/ConnectionDef.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/ConnectionDef.java
@@ -4,13 +4,12 @@ import java.util.Optional;
 
 import org.immutables.value.Value;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /** Connection details to connect to a database instance and execute queries. */
-@ConfigObject
+@ImmutableConfigObject
+@JacksonConfigObject
 @Value.Immutable
-@Value.Style(redactedMask = "***")
 @JsonDeserialize(builder = ImmutableConnectionDef.Builder.class)
 public interface ConnectionDef {
 

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/ImmutableConfigObject.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/ImmutableConfigObject.java
@@ -1,0 +1,21 @@
+package no.sysco.middleware.metrics.prometheus.jdbc.config;
+
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.immutables.value.Value;
+
+/** Immutables meta annotation for Config interfaces. */
+@Target({ PACKAGE, TYPE })
+@Retention(CLASS)
+@Value.Immutable
+@Value.Style( //
+    forceJacksonPropertyNames = false, // to make @JsonNaming work
+    redactedMask = "***" // how to mask confidential stuff in toString()
+)
+@interface ImmutableConfigObject {
+}

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/JacksonConfigObject.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/JacksonConfigObject.java
@@ -14,12 +14,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-/** Meta annotation for Config interfaces. */
+/** Jackson meta annotation for Config interfaces. */
 @Target(TYPE)
 @Retention(RUNTIME)
 @JacksonAnnotationsInside
 @JsonAutoDetect(fieldVisibility = NONE, getterVisibility = PUBLIC_ONLY, isGetterVisibility = PUBLIC_ONLY, setterVisibility = PUBLIC_ONLY)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(SnakeCaseStrategy.class)
-public @interface ConfigObject {
+@interface JacksonConfigObject {
 }

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/Job.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/Job.java
@@ -7,7 +7,8 @@ import org.immutables.value.Value;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /** A job that will be executed by the collector. */
-@ConfigObject
+@ImmutableConfigObject
+@JacksonConfigObject
 @Value.Immutable
 @JsonDeserialize(builder = ImmutableJob.Builder.class)
 public interface Job {

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/QueryDef.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/QueryDef.java
@@ -10,11 +10,11 @@ import org.immutables.value.Value;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.util.StdConverter;
 
 /** Query definition to collect metrics from a database. */
-@ConfigObject
+@ImmutableConfigObject
+@JacksonConfigObject
 @Value.Immutable
 @JsonDeserialize(builder = ImmutableQueryDef.Builder.class)
 public interface QueryDef {
@@ -51,7 +51,7 @@ public interface QueryDef {
     }
 }
 
-@ConfigObject
+@JacksonConfigObject
 final class JacksonQueryDefCacheSecondsConverter extends StdConverter<Long, Optional<Duration>> {
     @Override
     public Optional<Duration> convert(Long value) {

--- a/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/QueryString.java
+++ b/src/main/java/no/sysco/middleware/metrics/prometheus/jdbc/config/QueryString.java
@@ -2,7 +2,6 @@ package no.sysco.middleware.metrics.prometheus.jdbc.config;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Objects;
 import java.util.function.Function;
 
 import org.immutables.value.Value;
@@ -10,7 +9,8 @@ import org.immutables.value.Value;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-@ConfigObject
+@ImmutableConfigObject
+@JacksonConfigObject
 @Value.Enclosing
 @JsonDeserialize(builder = JacksonQueryStringBuilder.class)
 public abstract class QueryString {
@@ -26,7 +26,7 @@ public abstract class QueryString {
         return ImmutableQueryString.Ref.of(queryRef);
     }
 
-    @ConfigObject
+    @JacksonConfigObject
     @Value.Immutable(builder = false)
     @JsonDeserialize(as = ImmutableQueryString.Plain.class)
     public static abstract class Plain extends QueryString {
@@ -40,7 +40,7 @@ public abstract class QueryString {
         }
     }
 
-    @ConfigObject
+    @JacksonConfigObject
     @Value.Immutable(builder = false)
     @JsonDeserialize(as = ImmutableQueryString.Ref.class)
     public static abstract class Ref extends QueryString {
@@ -56,7 +56,7 @@ public abstract class QueryString {
     public abstract String resolve(Function<String, String> refResolver);
 }
 
-@ConfigObject
+@JacksonConfigObject
 final class JacksonQueryStringBuilder {
     private static final String UNSET = "sentinel";
 

--- a/src/test/java/no/sysco/middleware/metrics/prometheus/jdbc/config/ConfigTest.java
+++ b/src/test/java/no/sysco/middleware/metrics/prometheus/jdbc/config/ConfigTest.java
@@ -240,6 +240,10 @@ class ConfigTest {
             "    password: sys\n" + //
             "  queries:\n" + //
             "  - name: jdbc\n" + //
+            "    static_labels:\n" + //
+            "      stat: ic\n" + //
+            "    labels:\n" + //
+            "    - from_query\n" + //
             "    values:\n" + //
             "    - v1\n" + //
             "    query: abc\n" + //
@@ -254,6 +258,8 @@ class ConfigTest {
                     .addQueries(
                         ImmutableQueryDef.builder()
                             .name("jdbc")
+                            .putStaticLabels("stat", "ic")
+                            .addLabels("from_query")
                             .addValues("v1")
                             .query(QueryString.query("abc"))
                             .build())


### PR DESCRIPTION
So that the Jackson naming strategy gets effective.